### PR TITLE
Add local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,27 @@ CONTAINER_ID=ShiftPlanning
 
 The `.env` file is listed in `.gitignore` and should not be committed to the
 repository.
+
+## Running Locally
+
+This project uses Node.js version 20 as specified in `.nvmrc`. Ensure you are
+using this version (for example, run `nvm use`). Install dependencies with
+`npm install` and provide the required environment variables in a `.env` file as
+shown above.
+
+1. Start the Express API server:
+
+   ```bash
+   node backend/server.js
+   ```
+
+   The server listens on the port defined by the `PORT` environment variable or
+   defaults to `3000`.
+
+2. In a separate terminal, start the Next.js development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   This runs the Next.js app in development mode on port `3000` by default.


### PR DESCRIPTION
## Summary
- document Node 20 requirement from `.nvmrc`
- add steps for starting Express and Next.js dev servers

## Testing
- `npm test` *(fails: Missing script `test`)*