### PR TITLE
Fix build artifact path in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         run: ls -la ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
       - name: Archive build output
-        run: zip -r build.zip ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/
+        run: zip -r build.zip ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@v1
@@ -56,7 +56,7 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "."
+          app_location: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
           output_location: "build.zip"
 
   close_pull_request_job:


### PR DESCRIPTION
## Summary
- zip the Next.js export directory for deployment
- deploy the zipped directory

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*